### PR TITLE
Deprecate variant option1, option2 and option3

### DIFF
--- a/type/json/LineItem.d.ts
+++ b/type/json/LineItem.d.ts
@@ -45,7 +45,7 @@ export type LineItem = {
   };
   has_components: boolean;
 
-  // Deprecated values
+  // Deprecated properties
   /** @deprecated Use line_level_discount_allocations instead */
   discounts: [
     {

--- a/type/json/ProductVariant.d.ts
+++ b/type/json/ProductVariant.d.ts
@@ -8,9 +8,6 @@ export type ProductVariant = {
   compare_at_price: string;
   fulfillment_service: string;
   inventory_management: string;
-  option1: string | null;
-  option2: string | null;
-  option3: string | null;
   created_at: string;
   updated_at: string;
   taxable: boolean;
@@ -20,4 +17,12 @@ export type ProductVariant = {
   weight: number;
   weight_unit: 'g' | 'kg';
   requires_shipping: boolean;
+
+  // Deprecated properties
+  /** @deprecated Prefer to use options instead. */
+  option1: string | null;
+  /** @deprecated Prefer to use options instead. */
+  option2: string | null;
+  /** @deprecated Prefer to use options instead. */
+  option3: string | null;
 };

--- a/type/liquid/ProductVariant.d.ts
+++ b/type/liquid/ProductVariant.d.ts
@@ -4,9 +4,6 @@ import type { FeaturedVariantMedia } from './FeaturedVariantMedia';
 export type ProductVariant = {
   id: number;
   title: string;
-  option1: string;
-  option2: string | null;
-  option3: string | null;
   sku: string | null;
   requires_shipping: boolean;
   taxable: boolean;
@@ -26,4 +23,12 @@ export type ProductVariant = {
     max: number | null;
     min: number;
   };
+
+  // Deprecated properties
+  /** @deprecated Prefer to use options instead. */
+  option1: string | null;
+  /** @deprecated Prefer to use options instead. */
+  option2: string | null;
+  /** @deprecated Prefer to use options instead. */
+  option3: string | null;
 };


### PR DESCRIPTION
`option1`, `option2` and `option3` properties are officially deprecated. Use `options` instead.

https://shopify.dev/docs/api/liquid/objects/variant