### PR TITLE
Add /products/handle.js

### DIFF
--- a/type/js/AllocationPriceAdjustment.d.ts
+++ b/type/js/AllocationPriceAdjustment.d.ts
@@ -1,0 +1,4 @@
+export type AllocationPriceAdjustment = {
+  position: number;
+  price: number;
+};

--- a/type/js/FeaturedVariantImage.d.ts
+++ b/type/js/FeaturedVariantImage.d.ts
@@ -1,0 +1,12 @@
+export type FeaturedVariantImage = {
+  id: number;
+  product_id: number;
+  position: number;
+  created_at: string;
+  updated_at: string;
+  alt: string | null;
+  width: number;
+  height: number;
+  src: string;
+  variant_ids: number[];
+};

--- a/type/js/Product.d.ts
+++ b/type/js/Product.d.ts
@@ -1,7 +1,7 @@
-import { ProductVariant } from './ProductVariant';
-import { ProductOption } from './ProductOption';
-import { SellingPlanGroup } from './SellingPlanGroup';
-import { ProductMedia } from './ProductMedia';
+import type { ProductVariant } from './ProductVariant';
+import type { ProductOption } from './ProductOption';
+import type { SellingPlanGroup } from './SellingPlanGroup';
+import type { ProductMedia } from './ProductMedia';
 
 export type Product = {
   id: number;

--- a/type/js/Product.d.ts
+++ b/type/js/Product.d.ts
@@ -1,0 +1,33 @@
+import { ProductVariant } from './ProductVariant';
+import { ProductOption } from './ProductOption';
+import { SellingPlanGroup } from './SellingPlanGroup';
+import { ProductMedia } from './ProductMedia';
+
+export type Product = {
+  id: number;
+  title: string;
+  handle: string;
+  description: string;
+  published_at: string;
+  created_at: string;
+  vendor: string;
+  type: string;
+  tags: string[];
+  price: number;
+  price_min: number;
+  price_max: number;
+  available: boolean;
+  price_varies: boolean;
+  compare_at_price: number | null;
+  compare_at_price_min: number;
+  compare_at_price_max: number;
+  compare_at_price_varies: boolean;
+  variants: ProductVariant[];
+  images: string[];
+  featured_image: string;
+  options: ProductOption[];
+  url: string;
+  media: ProductMedia[];
+  requires_selling_plan: boolean;
+  selling_plan_groups: SellingPlanGroup[];
+};

--- a/type/js/ProductMedia.d.ts
+++ b/type/js/ProductMedia.d.ts
@@ -1,0 +1,13 @@
+import { PreviewImage } from '../liquid/PreviewImage';
+
+export type ProductMedia = {
+  alt: string | null;
+  id: number;
+  position: number;
+  preview_image: PreviewImage;
+  aspect_ratio: number;
+  height: number;
+  media_type: string;
+  src: string;
+  width: number;
+};

--- a/type/js/ProductMedia.d.ts
+++ b/type/js/ProductMedia.d.ts
@@ -1,4 +1,4 @@
-import { PreviewImage } from '../liquid/PreviewImage';
+import type { PreviewImage } from '../liquid/PreviewImage';
 
 export type ProductMedia = {
   alt: string | null;

--- a/type/js/ProductOption.d.ts
+++ b/type/js/ProductOption.d.ts
@@ -1,0 +1,5 @@
+export type ProductOption = {
+  name: string;
+  position: number;
+  values: string[];
+};

--- a/type/js/ProductVariant.d.ts
+++ b/type/js/ProductVariant.d.ts
@@ -1,0 +1,58 @@
+import { FeaturedVariantMedia } from '../liquid/FeaturedVariantMedia';
+import { SellingPlanAllocation } from './SellingPlanAllocation';
+
+export type QuantityPriceBreak = {
+  minimum_quantity: number;
+  price: number;
+};
+
+export type ProductVariant = {
+  id: number;
+  title: string;
+  option1: string;
+  option2: string | null;
+  option3: string | null;
+  sku: string | null;
+  requires_shipping: boolean;
+  taxable: boolean;
+  featured_image: {
+    id: number;
+    product_id: number;
+    position: number;
+    created_at: string;
+    updated_at: string;
+    alt: string | null;
+    width: number;
+    height: number;
+    src: string;
+    variant_ids: number[];
+  } | null;
+  available: boolean;
+  name: string;
+  public_title: string | null;
+  options: string[];
+  price: number;
+  weight: number;
+  compare_at_price: number | null;
+  inventory_management: string;
+  inventory_policy?: string;
+  inventory_quantity?: number;
+  barcode: string | null;
+  featured_media?: FeaturedVariantMedia;
+  quantity_rule: {
+    min: number;
+    max: number | null;
+    increment: number;
+  };
+  unit_price?: number;
+  unit_price_measurement?: {
+    measured_type: string;
+    quantity_value: string;
+    quantity_unit: string;
+    reference_value: number;
+    reference_unit: string;
+  };
+  quantity_price_breaks: QuantityPriceBreak[];
+  requires_selling_plan: boolean;
+  selling_plan_allocations: SellingPlanAllocation[];
+};

--- a/type/js/ProductVariant.d.ts
+++ b/type/js/ProductVariant.d.ts
@@ -1,5 +1,6 @@
-import { FeaturedVariantMedia } from '../liquid/FeaturedVariantMedia';
-import { SellingPlanAllocation } from './SellingPlanAllocation';
+import type { FeaturedVariantMedia } from '../liquid/FeaturedVariantMedia';
+import type { FeaturedVariantImage } from './FeaturedVariantImage';
+import type { SellingPlanAllocation } from './SellingPlanAllocation';
 
 export type QuantityPriceBreak = {
   minimum_quantity: number;
@@ -15,18 +16,7 @@ export type ProductVariant = {
   sku: string | null;
   requires_shipping: boolean;
   taxable: boolean;
-  featured_image: {
-    id: number;
-    product_id: number;
-    position: number;
-    created_at: string;
-    updated_at: string;
-    alt: string | null;
-    width: number;
-    height: number;
-    src: string;
-    variant_ids: number[];
-  } | null;
+  featured_image: FeaturedVariantImage | null;
   available: boolean;
   name: string;
   public_title: string | null;

--- a/type/js/SellingPlan.d.ts
+++ b/type/js/SellingPlan.d.ts
@@ -1,0 +1,11 @@
+import type { SellingPlanOption } from './SellingPlanOption';
+import type { SellingPlanPriceAdjustment } from './SellingPlanPriceAdjustment';
+
+export type SellingPlan = {
+  id: number;
+  name: string;
+  description: string;
+  options: SellingPlanOption[];
+  recurring_deliveries: boolean;
+  price_adjustments: SellingPlanPriceAdjustment[];
+};

--- a/type/js/SellingPlanAllocation.d.ts
+++ b/type/js/SellingPlanAllocation.d.ts
@@ -1,0 +1,12 @@
+export type SellingPlanAllocation = {
+  price_adjustments: {
+    position: number;
+    price: number;
+  }[];
+  price: number;
+  compare_at_price: number;
+  per_delivery_price: number;
+  unit_price?: number;
+  selling_plan_id: number;
+  selling_plan_group_id: string;
+};

--- a/type/js/SellingPlanAllocation.d.ts
+++ b/type/js/SellingPlanAllocation.d.ts
@@ -1,8 +1,7 @@
+import type { AllocationPriceAdjustment } from './AllocationPriceAdjustment';
+
 export type SellingPlanAllocation = {
-  price_adjustments: {
-    position: number;
-    price: number;
-  }[];
+  price_adjustments: AllocationPriceAdjustment[];
   price: number;
   compare_at_price: number;
   per_delivery_price: number;

--- a/type/js/SellingPlanGroup.d.ts
+++ b/type/js/SellingPlanGroup.d.ts
@@ -1,0 +1,25 @@
+import { ProductOption } from './ProductOption';
+
+export type SellingPlanGroup = {
+  id: string;
+  name: string;
+  options: Array<ProductOption>;
+  selling_plans: Array<{
+    id: number;
+    name: string;
+    description: string;
+    options: Array<{
+      name: string;
+      position: number;
+      value: string;
+    }>;
+    recurring_deliveries: boolean;
+    price_adjustments: Array<{
+      order_count: number | null;
+      position: number;
+      value_type: string;
+      value: number;
+    }>;
+  }>;
+  app_id: string;
+};

--- a/type/js/SellingPlanGroup.d.ts
+++ b/type/js/SellingPlanGroup.d.ts
@@ -1,25 +1,10 @@
-import { ProductOption } from './ProductOption';
+import type { ProductOption } from './ProductOption';
+import type { SellingPlan } from './SellingPlan';
 
 export type SellingPlanGroup = {
   id: string;
   name: string;
-  options: Array<ProductOption>;
-  selling_plans: Array<{
-    id: number;
-    name: string;
-    description: string;
-    options: Array<{
-      name: string;
-      position: number;
-      value: string;
-    }>;
-    recurring_deliveries: boolean;
-    price_adjustments: Array<{
-      order_count: number | null;
-      position: number;
-      value_type: string;
-      value: number;
-    }>;
-  }>;
+  options: ProductOption[];
+  selling_plans: SellingPlan[];
   app_id: string;
 };

--- a/type/js/SellingPlanOption.d.ts
+++ b/type/js/SellingPlanOption.d.ts
@@ -1,0 +1,5 @@
+export type SellingPlanOption = {
+  name: string;
+  position: number;
+  value: string;
+};

--- a/type/js/SellingPlanPriceAdjustment.d.ts
+++ b/type/js/SellingPlanPriceAdjustment.d.ts
@@ -1,0 +1,6 @@
+export type SellingPlanPriceAdjustment = {
+  order_count: number | null;
+  position: number;
+  value_type: string;
+  value: number;
+};


### PR DESCRIPTION
Adds types for the `/products/handle.js` endpoint.

References:
https://maguireshoes.com/products/olvera-snake-flip-flop-sandal.js (found via https://www.shopify.com/blog/shopify-stores)
https://puori.com/collections/shop/products/protein-creatine-bundle-bourbon-vanilla.js

